### PR TITLE
region specific domains

### DIFF
--- a/src/LeagueWrap/Region.php
+++ b/src/LeagueWrap/Region.php
@@ -11,38 +11,9 @@ class Region {
 	protected $region;
 
 	/**
-	 * An array of region dependant domains.
-	 *
-	 * @param array
+	 * The default domain to attempt to query
 	 */
-	protected $domains = [
-		'ru' => 'https://eu.api.pvp.net/api/lol/', 
-		'tr' => 'https://eu.api.pvp.net/api/lol/',
-		'kr' => 'https://kr.api.pvp.net/api/lol/',
-	];
-
-	/**
-	 * The default domain to attempt to query if the region is not
-	 * in the $domains array.
-	 *
-	 * @param string
-	 */
-	protected $defaultDomain = 'https://prod.api.pvp.net/api/lol/';
-
-	/**
-	 * An array of region dependant static data domains.
-	 *
-	 * @param array
-	 */
-	protected $staticDataDomains = [];
-
-	/**
-	 * The default domain to attempt to query if the region is not
-	 * in the $staticDataDomains array.
-	 *
-	 * @param string
-	 */
-	protected $defaultStaticDataDomain = 'https://prod.api.pvp.net/api/lol/static-data/';
+	protected $defaultDomain = 'https://%s.api.pvp.net/api/lol/';
 
 	public function __construct($region)
 	{
@@ -73,12 +44,7 @@ class Region {
 			return $this->getStaticDataDomain();
 		}
 
-		if (isset($this->domains[$this->region]))
-		{
-			return $this->domains[$this->region];
-		}
-
-		return $this->defaultDomain;
+		return sprintf($this->defaultDomain, $this->getRegion());
 	}
 
 	/**
@@ -88,12 +54,7 @@ class Region {
 	 */
 	public function getStaticDataDomain()
 	{
-		if (isset($this->staticDataDomains[$this->region]))
-		{
-			return $this->staticDataDomains[$this->region];
-		}
-
-		return $this->defaultStaticDataDomain;
+		return sprintf($this->defaultDomain . 'static-data/', $this->getRegion());
 	}
 
 	/**

--- a/tests/Api/ChampionTest.php
+++ b/tests/Api/ChampionTest.php
@@ -89,7 +89,7 @@ class ApiChampionTest extends PHPUnit_Framework_TestCase {
 	{
 		$this->client->shouldReceive('baseUrl')
 		             ->once()
-		             ->with('https://eu.api.pvp.net/api/lol/');
+		             ->with('https://ru.api.pvp.net/api/lol/');
 		$this->client->shouldReceive('request')
 		             ->with('ru/v1.2/champion', [
 						'freeToPlay' => 'false',

--- a/tests/RegionTest.php
+++ b/tests/RegionTest.php
@@ -22,13 +22,21 @@ class RegionTest extends PHPUnit_Framework_TestCase {
 
 	public function testGetDomainDefault()
 	{
+        $this->markTestIncomplete("There is no default domain anymore.");
+
 		$region = new Region('rawr');
 		$this->assertEquals('https://prod.api.pvp.net/api/lol/', $region->getDomain());
 	}
 
+    public function testGetDomain()
+    {
+        $region = new Region('euw');
+        $this->assertEquals('https://euw.api.pvp.net/api/lol/', $region->getDomain());
+    }
+
 	public function testGetDomainStaticData()
 	{
 		$region = new Region('na');
-		$this->assertEquals('https://prod.api.pvp.net/api/lol/static-data/', $region->getDomain(true));
+		$this->assertEquals('https://na.api.pvp.net/api/lol/static-data/', $region->getDomain(true));
 	}
 }


### PR DESCRIPTION
Added support for region specific domains (see https://developer.riotgames.com/discussion/riot-games-api/show/IH27EK1I) via sprintf. 

Unit tests are all passing except RegionTest#testGetDomainDefault because there is no default domain anymore. One option would be to check if region is valid and default to na.api.pvp.net if not.

regards,
danijoo
