### PR TITLE
Fix League API for players with multiple leagues.

### DIFF
--- a/src/LeagueWrap/Api/AbstractApi.php
+++ b/src/LeagueWrap/Api/AbstractApi.php
@@ -310,7 +310,7 @@ abstract class AbstractApi {
 		{
 			return $identity->id;
 		}
-		elseif (is_int($identity))
+		elseif (filter_var($identity, FILTER_VALIDATE_INT) !== FALSE)
 		{
 			return $identity;
 		}

--- a/src/LeagueWrap/Api/League.php
+++ b/src/LeagueWrap/Api/League.php
@@ -74,19 +74,14 @@ class League extends AbstractApi {
 			{
 				if (isset($info['participantId']))
 				{
-					$key        = $info['participantId'];
-					$info['id'] = $key;
+					$info['id'] = $info['participantId'];
 				}
 				else
 				{
 					$info['id'] = $id;
 				}
 				$league = new Dto\League($info);
-				if ( ! is_null($league->playerOrTeam))
-				{
-					$key = $league->playerOrTeam->playerOrTeamName;
-				}
-				$leagues[$key] = $league;
+				$leagues[] = $league;
 			}
 			$summoners[$id] = $leagues;
 		}

--- a/src/LeagueWrap/Api/Summoner.php
+++ b/src/LeagueWrap/Api/Summoner.php
@@ -91,7 +91,7 @@ class Summoner extends AbstractApi {
 		{
 			foreach ($identities as $identity)
 			{
-				if (is_int($identity))
+				if (filter_var($identity, FILTER_VALIDATE_INT) !== FALSE)
 				{
 					// it's the id
 					$ids[] = $identity;
@@ -105,7 +105,7 @@ class Summoner extends AbstractApi {
 		}
 		else
 		{
-			if (is_int($identities))
+			if (filter_var($identities, FILTER_VALIDATE_INT) !== FALSE)
 			{
 				// it's the id
 				$ids[] = $identities;

--- a/tests/Api/LeagueTest.php
+++ b/tests/Api/LeagueTest.php
@@ -30,7 +30,7 @@ class ApiLeagueTest extends PHPUnit_Framework_TestCase {
 
 		$api     = new Api('key', $this->client);
 		$leagues = $api->league()->league(272354);
-		$this->assertTrue($leagues['GamerXz'] instanceof LeagueWrap\Dto\League);
+		$this->assertTrue($leagues[0] instanceof LeagueWrap\Dto\League);
 	}
 
 	public function testLeagueSummoner()
@@ -113,7 +113,7 @@ class ApiLeagueTest extends PHPUnit_Framework_TestCase {
 			74602,
 			272354,
 		]);
-		$this->assertTrue($summoners[272354]['GamerXz'] instanceof LeagueWrap\Dto\League);
+		$this->assertTrue($summoners[272354][0] instanceof LeagueWrap\Dto\League);
 	}
 
 	public function testLeagueMultipleSummoners()
@@ -138,7 +138,7 @@ class ApiLeagueTest extends PHPUnit_Framework_TestCase {
 			7024,
 		]);
 		$api->league()->league($summoners);
-		$this->assertTrue($summoners['bakasan']->leagues['bakasan'] instanceof LeagueWrap\Dto\League);
+		$this->assertTrue($summoners['bakasan']->leagues[0] instanceof LeagueWrap\Dto\League);
 	}
 
 	public function testEntry()
@@ -153,7 +153,7 @@ class ApiLeagueTest extends PHPUnit_Framework_TestCase {
 
 		$api    = new Api('key', $this->client);
 		$league = $api->league()->league(74602, true);
-		$this->assertEquals(10, $league['bakasan']->playerOrTeam->leaguePoints);
+		$this->assertEquals(10, $league[0]->playerOrTeam->leaguePoints);
 	}
 
 	public function testEntrySummoners()
@@ -178,7 +178,7 @@ class ApiLeagueTest extends PHPUnit_Framework_TestCase {
 			7024,
 		]);
 		$api->league()->league($summoners, true);
-		$this->assertTrue($summoners['GamerXz']->leagues['GamerXz'] instanceof LeagueWrap\Dto\League);
+		$this->assertTrue($summoners['GamerXz']->leagues[0] instanceof LeagueWrap\Dto\League);
 	}
 
 	public function testChallenger()


### PR DESCRIPTION
Fix League API for players with multiple leagues.
Replace is_int with filter_var since some APIs will return summoner id's as strings.
