### PR TITLE
Updated Summoner "info" to support all-numeric summoner names

### DIFF
--- a/src/LeagueWrap/Api/Summoner.php
+++ b/src/LeagueWrap/Api/Summoner.php
@@ -82,9 +82,10 @@ class Summoner extends AbstractApi {
 	 * Gets the information about the user by the given identification.
      *
      * @param mixed $identities
+     * @param bool $strict (Optional) True to require IDs to be of type int, false to allow string IDs. Default false.
      * @return Dto\Summoner
 	 */
-	public function info($identities)
+	public function info($identities, $strict = false)
 	{
 		$ids   = [];
 		$names = [];
@@ -92,7 +93,8 @@ class Summoner extends AbstractApi {
 		{
 			foreach ($identities as $identity)
 			{
-				if (filter_var($identity, FILTER_VALIDATE_INT) !== FALSE)
+				if (filter_var($identity, FILTER_VALIDATE_INT) !== FALSE &&
+					(!$strict || gettype($identity) === 'integer'))
 				{
 					// it's the id
 					$ids[] = $identity;
@@ -106,7 +108,8 @@ class Summoner extends AbstractApi {
 		}
 		else
 		{
-			if (filter_var($identities, FILTER_VALIDATE_INT) !== FALSE)
+			if (filter_var($identities, FILTER_VALIDATE_INT) !== FALSE &&
+				(!$strict || gettype($identities) === 'integer'))
 			{
 				// it's the id
 				$ids[] = $identities;
@@ -137,7 +140,7 @@ class Summoner extends AbstractApi {
 			}
 		}
 
-		$summoners = array_merge($ids, $names);
+		$summoners = $ids + $names;
 
 		if (count($summoners) == 1)
 		{

--- a/tests/Api/SummonerTest.php
+++ b/tests/Api/SummonerTest.php
@@ -72,6 +72,30 @@ class ApiSummonerTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue(isset($summoners['IS1c2d27157a9df3f5aef47']));
 	}
 
+	public function testInfoStrict()
+	{
+		$this->client->shouldReceive('baseUrl')
+		             ->twice();
+		$this->client->shouldReceive('request')
+		             ->with('na/v1.4/summoner/by-name/1337', [
+						'api_key' => 'key',
+		             ])->once()
+		             ->andReturn(file_get_contents('tests/Json/summoner.1337.json'));
+		$this->client->shouldReceive('request')
+		             ->with('na/v1.4/summoner/74602', [
+						'api_key' => 'key',
+		             ])->once()
+		             ->andReturn(file_get_contents('tests/Json/summoner.74602.json'));
+
+		$api = new Api('key', $this->client);
+		$summoners = $api->summoner()->info([
+			'1337',
+			74602
+		], true);
+		$this->assertTrue(isset($summoners['bakasan']));
+		$this->assertTrue(isset($summoners['1337']));
+	}
+
 	public function testName()
 	{
 		$this->client->shouldReceive('baseUrl')

--- a/tests/Json/summoner.1337.json
+++ b/tests/Json/summoner.1337.json
@@ -1,0 +1,1 @@
+{"1337":{"id":1324845,"name":"1337","profileIconId":554,"summonerLevel":30,"revisionDate":1391138252000}}


### PR DESCRIPTION
It is possible for a summoner's name to be made of of only numbers, e.g. `1337`

If `->info([1337])` is invoked with the intention of looking that summoner up by name, it will detect an ID and look based on the ID instead. This is because `FILTER_VALIDATE_INT` does not actually do a typecheck:

```
`$ php -r 'echo filter_var(1337, FILTER_VALIDATE_INT) === filter_var("1337", FILTER_VALIDATE_INT);'
1
```

The simplest way to fix this is to use `gettype(...)` instead of `FILTER_VALIDATE_INT`; however, that would introduce a backwards-compatibility break, and I don't know if you're allowing those at this time or not (even though it's technically a bug, IMO).

So, instead, I added an optional `$strict` parameter, which if true, indicates that it should check that the _type_ is integer before deciding that it's an ID vs. a name. The default is false, so anybody currently using the library is unaffected.

**Note:** I had to change the `array_merge(...)` to the `+` operator instead, since PHP will reindex numeric arrays if you use `array_merge(...)`. Since numeric summoner names are, well, numeric, it will reindex the keys when merging and not be predictably accessible.

If you don't mind the BC break, let me know and I'll be happy to submit a different PR for the "more proper" fix. Just keep in mind that anybody currently using this library and looking summoners up by ID will have problems when they update, unless they were already typecasting IDs to integer.
