### PR TITLE
Addendum to "Updated Summoner "info" to support all-numeric summoner names"

### DIFF
--- a/src/LeagueWrap/Api/Summoner.php
+++ b/src/LeagueWrap/Api/Summoner.php
@@ -79,13 +79,13 @@ class Summoner extends AbstractApi {
 	}
 
 	/**
-	 * Gets the information about the user by the given identification.
-     *
-     * @param mixed $identities
-     * @param bool $strict (Optional) True to require IDs to be of type int, false to allow string IDs. Default false.
-     * @return Dto\Summoner
+	 * Gets the information about the user by the given identification. IDs must be of type integer, otherwise,
+	 * numeric string values will be assumed to be names.
+	 *
+	 * @param mixed $identities
+	 * @return Dto\Summoner
 	 */
-	public function info($identities, $strict = false)
+	public function info($identities)
 	{
 		$ids   = [];
 		$names = [];
@@ -93,8 +93,7 @@ class Summoner extends AbstractApi {
 		{
 			foreach ($identities as $identity)
 			{
-				if (filter_var($identity, FILTER_VALIDATE_INT) !== FALSE &&
-					(!$strict || gettype($identity) === 'integer'))
+				if (gettype($identity) === 'integer')
 				{
 					// it's the id
 					$ids[] = $identity;
@@ -108,8 +107,7 @@ class Summoner extends AbstractApi {
 		}
 		else
 		{
-			if (filter_var($identities, FILTER_VALIDATE_INT) !== FALSE &&
-				(!$strict || gettype($identities) === 'integer'))
+			if (gettype($identities) === 'integer')
 			{
 				// it's the id
 				$ids[] = $identities;

--- a/tests/Api/SummonerTest.php
+++ b/tests/Api/SummonerTest.php
@@ -72,7 +72,7 @@ class ApiSummonerTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue(isset($summoners['IS1c2d27157a9df3f5aef47']));
 	}
 
-	public function testInfoStrict()
+	public function testInfoDistinguishesBetweenIntegerIdsAndNumericNames()
 	{
 		$this->client->shouldReceive('baseUrl')
 		             ->twice();
@@ -91,7 +91,7 @@ class ApiSummonerTest extends PHPUnit_Framework_TestCase {
 		$summoners = $api->summoner()->info([
 			'1337',
 			74602
-		], true);
+		]);
 		$this->assertTrue(isset($summoners['bakasan']));
 		$this->assertTrue(isset($summoners['1337']));
 	}


### PR DESCRIPTION
Here is the BC break version. Cleans up the `if` statements a bit and doesn't require the special parameter.
