### PR TITLE
add optional matchhistory arguments

### DIFF
--- a/src/LeagueWrap/Api/Matchhistory.php
+++ b/src/LeagueWrap/Api/Matchhistory.php
@@ -40,21 +40,52 @@ class Matchhistory extends AbstractApi {
     protected $defaultRemember = 1800;
 
     /**
-     * Get the match history by summoner id.
-     *
-     * @param mixed $id
-     * @return array
+     * Get the match history by summoner identity.
+     * @param $identity int|Summoner
+     * @param array|string|null $rankedQueues List of ranked queue types to use for fetching games.
+     * @param array|string|null $championIds Comma-separated list of champion IDs to use for fetching games.
+     * @param int|null $beginIndex The begin index to use for fetching games.
+     * @param int|null $endIndex The end index to use for fetching games.
+     * @return \LeagueWrap\Dto\MatchHistory
+     * @throws \LeagueWrap\Exception\CacheNotFoundException
+     * @throws \LeagueWrap\Exception\InvalidIdentityException
+     * @throws \LeagueWrap\Exception\RegionException
      */
-    public function history($identity)
+    public function history($identity, $rankedQueues=null, $championIds=null, $beginIndex=null, $endIndex=null)
     {
         $id = $this->extractId($identity);
 
-        $array = $this->request('matchhistory/'.$id);
+        $requestParamas = $this->parseParams($rankedQueues, $championIds, $beginIndex, $endIndex);
+        $array = $this->request('matchhistory/'.$id, $requestParamas);
         $matchhistory = new \LeagueWrap\Dto\MatchHistory($array);
 
         $this->attachResponse($identity, $matchhistory, 'matchhistory');
 
         return $matchhistory;
+    }
+
+    protected function parseParams($rankedQueues=null, $championIds=null, $beginIndex=null, $endIndex=null)
+    {
+        $params = [];
+
+        if(isset($rankedQueues))
+            if(is_array($rankedQueues))
+                $params['rankedQueues'] = implode(',', $rankedQueues);
+            else
+                $params['rankedQueues'] = $rankedQueues;
+
+        if(isset($championIds))
+            if(is_array($championIds))
+                $params['championIds'] = implode(',', $championIds);
+            else
+                $params['championIds'] = $championIds;
+
+        if(isset($beginIndex))
+            $params['beginIndex'] = $beginIndex;
+        if(isset($endIndex))
+            $params['endIndex'] = $endIndex;
+
+        return $params;
     }
 
 } 


### PR DESCRIPTION
The matchhistory endpoint now supports additional arguments to filter the games by various options and indexes. This Pull adds those functionality to leaguewrap

Related forum post: https://developer.riotgames.com/discussion/riot-games-api/show/1mlmxmc4
