### PR TITLE
Update AbstractApi.php

### DIFF
--- a/src/LeagueWrap/Api/AbstractApi.php
+++ b/src/LeagueWrap/Api/AbstractApi.php
@@ -322,8 +322,16 @@ abstract class AbstractApi {
 			{
 				$content = $this->clientRequest($static, $uri, $params);
 
-				// we want to cache this response
-				$this->cache->set($content, $cacheKey, $this->seconds);
+				$cacheContent = true;
+				//if you got a Response object check if the response code is a valid 200
+				if($content instanceof Response) {
+					$cacheContent = $content->getCode() === 200;
+				}
+
+				if($cacheContent) {
+					// we want to cache this response
+					$this->cache->set($content, $cacheKey, $this->seconds);
+				}
 			}
 		}
 		elseif ($this->cacheOnly)


### PR DESCRIPTION
I had a problem with caching none 200 code responses, mostly with the "currentGame" request. Every Response was cached, even the 503 oder 404 ones, with the amount of seconds i specified.

The code checks if the returned content is a Response object. If it is it will check the setted code for a 200 response and only this ones will be cached. 
If the content is not a Resonse object it will be cached without restriction.

like @danijoo suggested, there should be a kind of flag where you can determin if a none 200 response should be valid too and should be cached as well: https://github.com/paquettg/leaguewrap/issues/69