### PR TITLE
Fixed memcached expiration time

### DIFF
--- a/src/LeagueWrap/Cache.php
+++ b/src/LeagueWrap/Cache.php
@@ -26,7 +26,7 @@ class Cache implements CacheInterface {
 	 */
 	public function set($response, $key, $seconds)
 	{
-		return $this->memcached->set($key, $response, time() + $seconds);
+		return $this->memcached->set($key, $response, $seconds);
 	}
 
 	/**


### PR DESCRIPTION
There seems to be an error in [Memcached documentation](http://php.net/manual/en/memcached.set.php) regarding expiration times ([see this comment](http://php.net/manual/en/memcached.set.php#118157))

If you want to test it yourself have a look at: http://cl.ly/dYd8

![](https://s3.amazonaws.com/f.cl.ly/items/3j2v0l2b2f261r0q0f2l/Screen%20Shot%202015-10-18%20at%2012.09.44.png)