### PR TITLE
Fixed parameter order of Cache->set

### DIFF
--- a/src/LeagueWrap/Api/AbstractApi.php
+++ b/src/LeagueWrap/Api/AbstractApi.php
@@ -271,14 +271,14 @@ abstract class AbstractApi {
 				{
 					$content = $this->clientRequest($static, $uri, $params);
 					// we want to cache this response
-					$this->cache->set($content, $cacheKey, $this->seconds);
+					$this->cache->set($cacheKey, $content, $this->seconds);
 				}
 				catch (HttpClientError $clientError)
 				{
 					if ($this->cacheClientError)
 					{
 						// cache client errors
-						$this->cache->set($clientError, $cacheKey, $this->seconds);
+						$this->cache->set($cacheKey, $clientError, $this->seconds);
 					}
 					// rethrow the exception
 					throw $clientError;
@@ -288,7 +288,7 @@ abstract class AbstractApi {
 					if ($this->cacheServerError)
 					{
 						// cache server errors
-						$this->cache->set($serverError, $cacheKey, $this->seconds);
+						$this->cache->set($cacheKey, $serverError, $this->seconds);
 					}
 					// rethrow the exception
 					throw $serverError;

--- a/src/LeagueWrap/Cache.php
+++ b/src/LeagueWrap/Cache.php
@@ -19,12 +19,12 @@ class Cache implements CacheInterface {
 	/**
 	 * Adds the response string into the cache under the given key.
 	 *
-	 * @param string $response
 	 * @param string $key
+	 * @param string $response
 	 * @param int $seconds
 	 * @return bool
 	 */
-	public function set($response, $key, $seconds)
+	public function set($key, $response, $seconds)
 	{
 		return $this->memcached->set($key, $response, $seconds);
 	}

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -23,7 +23,7 @@ class CacheTest extends PHPUnit_Framework_TestCase {
 		$champions = file_get_contents('tests/Json/champion.free.json');
 		$this->cache->shouldReceive('set')
 		            ->once()
-		            ->with($champions, '4be3fe5c15c888d40a1793190d77166b', 60)
+		            ->with('4be3fe5c15c888d40a1793190d77166b', $champions, 60)
 		            ->andReturn(true);
 		$this->cache->shouldReceive('has')
 		            ->twice()
@@ -138,7 +138,7 @@ class CacheTest extends PHPUnit_Framework_TestCase {
 		$bakasan = file_get_contents('tests/Json/summoner.bakasan.json');
 		$this->cache->shouldReceive('set')
 		            ->once()
-		            ->with($bakasan, '9bd8e5b11e0ac9c0a52d5711c9057dd2', 10)
+		            ->with('9bd8e5b11e0ac9c0a52d5711c9057dd2', $bakasan, 10)
 		            ->andReturn(true);
 		$this->cache->shouldReceive('has')
 		            ->twice()
@@ -171,7 +171,7 @@ class CacheTest extends PHPUnit_Framework_TestCase {
 		$exception = new LeagueWrap\Response\Http404('', 404);
 		$this->cache->shouldReceive('set')
 		            ->once()
-		            ->with(m::any(), '9bd8e5b11e0ac9c0a52d5711c9057dd2', 10)
+		            ->with('9bd8e5b11e0ac9c0a52d5711c9057dd2', m::any(), 10)
 		            ->andReturn(true);
 		$this->cache->shouldReceive('has')
 		            ->twice()
@@ -248,7 +248,7 @@ class CacheTest extends PHPUnit_Framework_TestCase {
 
 		$this->cache->shouldReceive('set')
 		            ->once()
-		            ->with(m::any(), '9bd8e5b11e0ac9c0a52d5711c9057dd2', 10)
+		            ->with('9bd8e5b11e0ac9c0a52d5711c9057dd2', m::any(), 10)
 		            ->andReturn(true);
 		$this->cache->shouldReceive('has')
 		            ->twice()


### PR DESCRIPTION
The parameter order of Cache->set had $response before $key instead of vice-versa. CacheInterface.php had it in the "proper" order, following the parameter order of Memcached.