### PR TITLE
Added__isset method is AbstractDTO to enhance Twig compatibility and fixed case mismatch in namespace

### DIFF
--- a/src/LeagueWrap/Dto/AbstractDto.php
+++ b/src/LeagueWrap/Dto/AbstractDto.php
@@ -21,7 +21,8 @@ Abstract class AbstractDto {
 	/**
 	 * Check if an attribute exists
 	 *
-	 * @param array $info
+	 * @param string $key
+	 * @return bool
 	 */
 	public function __isset($key)
 	{

--- a/src/LeagueWrap/Dto/AbstractDto.php
+++ b/src/LeagueWrap/Dto/AbstractDto.php
@@ -24,10 +24,10 @@ Abstract class AbstractDto {
 	 * @param array $info
 	 */
 	public function __isset($key)
-    {
-        return !is_null($this->$key);
-    }
-    
+	{
+		return !is_null($this->$key);
+	}
+
 	/**
 	 * Gets the attribute of this Dto.
 	 *

--- a/src/LeagueWrap/Dto/AbstractDto.php
+++ b/src/LeagueWrap/Dto/AbstractDto.php
@@ -19,6 +19,16 @@ Abstract class AbstractDto {
 	}
 
 	/**
+	 * Check if an attribute exists
+	 *
+	 * @param array $info
+	 */
+	public function __isset($key)
+    {
+        return !is_null($this->$key);
+    }
+    
+	/**
 	 * Gets the attribute of this Dto.
 	 *
 	 * @param string $key

--- a/src/LeagueWrap/Dto/MatchReference.php
+++ b/src/LeagueWrap/Dto/MatchReference.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Leaguewrap\Dto;
+namespace LeagueWrap\Dto;
 
 /**
  * Class MatchReference

--- a/src/LeagueWrap/StaticApi.php
+++ b/src/LeagueWrap/StaticApi.php
@@ -1,5 +1,5 @@
 <?php
-namespace Leaguewrap;
+namespace LeagueWrap;
 
 final class StaticApi {
 


### PR DESCRIPTION
Twig needs the __isset() method to access objects properties :
http://twig.sensiolabs.org/doc/recipes.html#using-dynamic-object-properties