### PR TITLE
Prevent $body->read() error.

### DIFF
--- a/src/LeagueWrap/Client.php
+++ b/src/LeagueWrap/Client.php
@@ -88,7 +88,7 @@ class Client implements ClientInterface {
 		if ($body instanceof Stream)
 		{
 			$body->seek(0);
-			$content = $body->read($body->getSize());
+			$content = ($body->getSize() > 0) ? $body->read($body->getSize()) : null;
 		}
 		else
 		{


### PR DESCRIPTION
For Line 91: If getSize(" equals 0 due to a page not returning anything, such as a 404 response, then read() will make an exception stating that the byte size needs to be more than 0. No need to use read() if the body is null or empty. So $content will take null as is just to return the empty body. Only the $code will matter at this point for the Response() instance.

This error occurs only for League() as far as I know. Even Summoner() provides error content.