### PR TITLE
Fix class name in Championmastery.php

### DIFF
--- a/src/LeagueWrap/Api/Championmastery.php
+++ b/src/LeagueWrap/Api/Championmastery.php
@@ -5,7 +5,7 @@ namespace LeagueWrap\Api;
 
 use LeagueWrap\Dto\ChampionMasteryList;
 
-class ChampionMastery extends AbstractApi
+class Championmastery extends AbstractApi
 {
 
     /**


### PR DESCRIPTION
Case mismatch between loaded and declared class names:
LeagueWrap\Api\Championmastery vs LeagueWrap\Api\ChampionMastery