### PR TITLE
fix for xdebug errors

### DIFF
--- a/src/LeagueWrap/Dto/ImportStaticTrait.php
+++ b/src/LeagueWrap/Dto/ImportStaticTrait.php
@@ -19,6 +19,8 @@ trait ImportStaticTrait {
 		];
 		foreach ($this->staticFields as $field => $data)
 		{
+			if( !isset($this->info[$field]) )
+				continue;
 			$fieldValue = $this->info[$field];
 			if ( ! isset($fields[$splHash][$data]))
 			{
@@ -46,6 +48,8 @@ trait ImportStaticTrait {
 		foreach ($this->staticFields as $field => $data)
 		{
 			$infoArray  = $info[$data];
+			if( !isset($this->info[$field]) )
+				continue;
 			$fieldValue = $this->info[$field];
 			$staticData = $infoArray[$fieldValue];
 

--- a/src/LeagueWrap/Dto/ImportStaticTrait.php
+++ b/src/LeagueWrap/Dto/ImportStaticTrait.php
@@ -47,9 +47,9 @@ trait ImportStaticTrait {
 		$info    = $optimizer->getDataFromHash($splHash);
 		foreach ($this->staticFields as $field => $data)
 		{
-			$infoArray  = $info[$data];
 			if( !isset($this->info[$field]) )
 				continue;
+			$infoArray  = $info[$data];
 			$fieldValue = $this->info[$field];
 			$staticData = $infoArray[$fieldValue];
 

--- a/src/LeagueWrap/StaticOptimizer.php
+++ b/src/LeagueWrap/StaticOptimizer.php
@@ -19,7 +19,7 @@ class StaticOptimizer {
 	 *
 	 * @param array
 	 */
-	protected $requests;
+	protected $requests = [];
 
 	/**
 	 * Keep the results from the requests in $requests.


### PR DESCRIPTION
 "Invalid argument supplied for foreach()"
the error occured after `Api::attachStaticData()` whenever a Dto was created which does not have `staticFields`

with this little change i'm finally able to use attachStaticData()