### PR TITLE
Attach response to response exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,15 @@ catch (LeagueWrap\Response\ResponseException $e)
 {
 	// All http error codes extends from this abstract class.
 	// This is a catch all (both 4xx and 5xx http errors)
+	
+	// To get more detailed information about the response, the following methods are available
+	$e->hasResponse(); // Checks if response was attached
+	$response = $e->getResponse(); // Instance of LeagueWrap\Response
+	// In some cases like resolving 429 status codes, information from headers could be useful
+	// see: https://developer.riotgames.com/docs/rate-limiting 
+	$headers = $response->getHeaders(); // ['Retry-After' => ..., ...]
+	$response->hasHeader('Retry-After');
+	$response->getHeader('that does not exist'); // null
 }
 catch (LeagueWrap\Response\UnderlyingServiceRateLimitReached $e)
 {

--- a/src/LeagueWrap/Api/AbstractApi.php
+++ b/src/LeagueWrap/Api/AbstractApi.php
@@ -519,9 +519,10 @@ abstract class AbstractApi {
 	{
 		$code = $response->getCode();
 		if ($code === 429 && !$response->hasHeader('Retry-After')) {
-		    throw new Response\UnderlyingServiceRateLimitReached(
+			throw Response\UnderlyingServiceRateLimitReached::withResponse(
 				"Did not receive 'X-Rate-Limit-Type' and 'Retry-After' headers. ".
-				"See https://developer.riotgames.com/docs/rate-limiting for more details"
+				"See https://developer.riotgames.com/docs/rate-limiting for more details",
+				$response
 			);
 		}
 		if (intval($code / 100) != 2)
@@ -534,7 +535,13 @@ abstract class AbstractApi {
 			}
 
 			$class = 'LeagueWrap\Response\Http'.$code;
-			throw new $class($message, $code);
+			$exception = new $class($message, $code);
+
+			if ($exception instanceof Response\ResponseException) {
+				throw $class::withResponse($message, $response);
+			}
+
+			throw $exception;
 		}
 	}
 }

--- a/src/LeagueWrap/Api/AbstractApi.php
+++ b/src/LeagueWrap/Api/AbstractApi.php
@@ -16,6 +16,7 @@ use LeagueWrap\Exception\RegionException;
 use LeagueWrap\Exception\LimitReachedException;
 use LeagueWrap\Exception\InvalidIdentityException;
 use LeagueWrap\Exception\CacheNotFoundException;
+use LeagueWrap\Response\ResponseException;
 
 abstract class AbstractApi {
 
@@ -535,13 +536,10 @@ abstract class AbstractApi {
 			}
 
 			$class = 'LeagueWrap\Response\Http'.$code;
-			$exception = new $class($message, $code);
 
-			if ($exception instanceof Response\ResponseException) {
+			if (class_exists($class) && is_subclass_of($class, ResponseException::class)) {
 				throw $class::withResponse($message, $response);
 			}
-
-			throw $exception;
 		}
 	}
 }

--- a/src/LeagueWrap/Exception/NoResponseIncludedException.php
+++ b/src/LeagueWrap/Exception/NoResponseIncludedException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace LeagueWrap\Exception;
+
+final class NoResponseIncludedException extends \Exception
+{
+
+}

--- a/src/LeagueWrap/Response/ResponseException.php
+++ b/src/LeagueWrap/Response/ResponseException.php
@@ -2,7 +2,59 @@
 namespace LeagueWrap\Response;
 
 use Exception;
+use LeagueWrap\Exception\NoResponseIncludedException;
+use LeagueWrap\Response;
 
 abstract class ResponseException extends Exception {
+    /**
+     * Response that caused this exception.
+     *
+     * @var Response
+     */
+    protected $response;
 
+    /**
+     * Static constructor for including response.
+     *
+     * @param string   $message
+     * @param Response $response
+     *
+     * @return static
+     */
+    public static function withResponse($message, Response $response)
+    {
+        $e = new static();
+        $e->response = $response;
+        $e->message = $message;
+
+        return $e;
+    }
+
+    /**
+     * Check if response was provided.
+     *
+     * @return bool
+     */
+    public function hasResponse()
+    {
+        return !!$this->response;
+    }
+
+    /**
+     * Access the response.
+     *
+     * @throws NoResponseIncludedException
+     * @return Response
+     */
+    public function getResponse()
+    {
+        if (!$this->response) {
+            throw new NoResponseIncludedException(
+                'No response information was provided. '.
+                'Use hasResponse() to check if this exception has response attached.'
+            );
+        }
+        
+        return $this->response;
+    }
 }

--- a/tests/Exceptions/ResponseExceptionTest.php
+++ b/tests/Exceptions/ResponseExceptionTest.php
@@ -1,0 +1,104 @@
+<?php
+
+use LeagueWrap\Api;
+use LeagueWrap\Exception\NoResponseIncludedException;
+use LeagueWrap\Response;
+use LeagueWrap\Response\Http404;
+use LeagueWrap\Response\Http429;
+use LeagueWrap\Response\ResponseException;
+use LeagueWrap\Response\UnderlyingServiceRateLimitReached;
+use Mockery as m;
+
+class ResponseExceptionTest extends PHPUnit_Framework_TestCase
+{
+    protected $client;
+
+    public function setUp()
+    {
+        $client = m::mock('LeagueWrap\Client');
+        $this->client = $client;
+    }
+
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    private function simulateWithResponse(Response $response)
+    {
+        $this->client->shouldReceive('baseUrl')->with('https://na.api.pvp.net/api/lol/na/')
+            ->once();
+        $this->client->shouldReceive('request')
+            ->with('v1.2/champion', [
+                'freeToPlay' => 'false',
+                'api_key' => 'key',
+            ])->once()
+            ->andReturn($response);
+    }
+
+    public function testHttp429ExceptionContainsResponse()
+    {
+        try {
+            $this->simulateWithResponse(new Response('', 429, [
+                'Retry-After' => [
+                    123
+                ],
+                'X-Rate-Limit-Type' => [
+                    'user'
+                ],
+            ]));
+
+            $api = new Api('key', $this->client);
+            $api->champion()->all();
+        } catch (ResponseException $e) {
+            $this->assertTrue($e->hasResponse());
+            $this->assertInstanceOf(Http429::class, $e);
+            $this->assertInstanceOf(Response::class, $e->getResponse());
+
+            $this->assertTrue($e->getResponse()->hasHeader('Retry-After'));
+            $this->assertTrue($e->getResponse()->hasHeader('X-Rate-Limit-Type'));
+            $this->assertFalse($e->getResponse()->hasHeader('that does not exist'));
+
+            $this->assertCount(2, $e->getResponse()->getHeaders());
+            $this->assertEquals([
+                'Retry-After' => 123,
+                'X-Rate-Limit-Type' => 'user',
+            ], $e->getResponse()->getHeaders());
+
+            $this->assertEquals(123, $e->getResponse()->getHeader('Retry-After'));
+            $this->assertEquals('user', $e->getResponse()->getHeader('X-Rate-Limit-Type'));
+            $this->assertNull($e->getResponse()->getHeader('that does not exist'));
+        }
+    }
+
+    public function testUnderlyingServiceExceptionContainsResponse()
+    {
+        try {
+            $this->simulateWithResponse(new Response('', 429, []));
+
+            $api = new Api('key', $this->client);
+            $api->champion()->all();
+        } catch (ResponseException $e) {
+            $this->assertTrue($e->hasResponse());
+            $this->assertInstanceOf(UnderlyingServiceRateLimitReached::class, $e);
+            $this->assertInstanceOf(Response::class, $e->getResponse());
+
+            $this->assertFalse($e->getResponse()->hasHeader('Retry-After'));
+            $this->assertFalse($e->getResponse()->hasHeader('X-Rate-Limit-Type'));
+
+            $this->assertCount(0, $e->getResponse()->getHeaders());
+            $this->assertEquals([], $e->getResponse()->getHeaders());
+
+            $this->assertNull($e->getResponse()->getHeader('Retry-After'));
+            $this->assertNull($e->getResponse()->getHeader('X-Rate-Limit-Type'));
+        }
+    }
+
+    public function testExceptionDoesNotContainResponse()
+    {
+        $this->setExpectedException(NoResponseIncludedException::class);
+
+        $e = new Http404('Oops.', 404);
+        $response = $e->getResponse();
+    }
+}


### PR DESCRIPTION
This PR attaches `Response` to `ResponseException` for better accessibility to headers. It is an extension to PR #122, based on proposal in #119.

```php
try {
    // ...
} catch (LeagueWrap\Response\ResponseException $e) {
	$response = $e->getResponse(); // Instance of LeagueWrap\Response
	// In some cases like resolving 429 status codes, information from headers could be useful
	// see: https://developer.riotgames.com/docs/rate-limiting 
	$headers = $response->getHeaders(); // ['Retry-After' => ..., ...]
	$response->hasHeader('Retry-After');
	$response->getHeader('that does not exist'); // null
}
```